### PR TITLE
Route change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except(IOError, ImportError):
 
 setup(
     name='waspy',
-    version='0.9.2',
+    version='0.10.0',
     install_requires=[
         'h11==0.7.0',
         'aioamqp==0.8.2',

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -9,11 +9,13 @@ def router():
     router_.add_get('/single', 1)
     router_.add_get('/double/double', 2)
     router_.add_get('/something/static/and/long', 3)
-    router_.add_get('/single/:id', 4)
-    router_.add_get('/foo/:fooid/bar/:barid', 5)
-    router_.add_get('/foo/:fooid/bar', 6)
-    router_.add_get('/foo/bar/baz/:id', 7)
-    router_.add_get('/multiple/:ids/:in/:a/row', 8)
+    router_.add_get('/single/{id}', 4)
+    router_.add_get('/foo/{fooid}/bar/{barid}', 5)
+    router_.add_get('/foo/{fooid}/bar', 6)
+    router_.add_get('/foo/bar/baz/{id}', 7)
+    router_.add_get('/multiple/{ids}/{in}/{a}/row', 8)
+    router_.add_get('/foo/{fooid}:action', 9)
+    router_.add_get('/foo/{fooid}:action2', 10)
 
     # now wrap all handlers with nothing
     handler_gen = router_._get_and_wrap_routes()
@@ -32,11 +34,13 @@ def router():
     ('/single', 1, []),
     ('/double/double', 2, []),
     ('/something/static/and/long', 3, []),
-    ('/single/:id', 4, ['id']),
-    ('/foo/:fooid/bar/:barid', 5, ['fooid', 'barid']),
-    ('/foo/:fooid/bar', 6, ['fooid']),
-    ('/foo/bar/baz/:id', 7, ['id']),
-    ('/multiple/:ids/:in/:a/row', 8, ['ids', 'in', 'a']),
+    ('/single/_id', 4, ['id']),
+    ('/foo/_fooid/bar/_barid', 5, ['fooid', 'barid']),
+    ('/foo/_fooid/bar', 6, ['fooid']),
+    ('/foo/bar/baz/_id', 7, ['id']),
+    ('/multiple/_ids/_in/_a/row', 8, ['ids', 'in', 'a']),
+    ('/foo/_fooid:action', 9, ['fooid']),
+    ('/foo/_fooid:action2', 10, ['fooid']),
 ])
 def test_get_handler(path, expected_handler, expected_params, router):
     # Set up dummy request
@@ -50,5 +54,5 @@ def test_get_handler(path, expected_handler, expected_params, router):
     assert handler == expected_handler
     for key in expected_params:
         assert key in request.path_params
-        assert request.path_params[key] == ':' + key
+        assert request.path_params[key] == '_' + key
 

--- a/waspy/__init__.py
+++ b/waspy/__init__.py
@@ -1,3 +1,4 @@
 from .app import Application
-from .webtypes import Request, Response, ResponseError, QueryParams
+from .webtypes import Request, Response, ResponseError, \
+    QueryParams, JSONDecodeError
 from .configuration import Config

--- a/waspy/errorlogging.py
+++ b/waspy/errorlogging.py
@@ -6,6 +6,11 @@ logger = logging.getLogger('waspy')
 
 class ErrorLoggingBase:
     def log_exception(self, request, exc_info, level='error'):
+        try:
+            level = getattr(logging, level.upper())
+        except:
+            level = logging.ERROR
+
         logger.log(level, 'An error occurred while handling request: {}'
                    .format(request),
                    exc_info=exc_info)
@@ -55,7 +60,7 @@ class SentryLogging(ErrorLoggingBase):
         self.raven.captureMessage(message, data=data, extra=extra, tags=tags)
 
     def log_exception(self, request, exc_info, level='error'):
-        super().log_exception(request, exc_info)
+        super().log_exception(request, exc_info, level=level)
 
         data, tags, extra = self._get_sentry_details(request, exc_info)
         self.raven.captureException(data=data, extra=extra, tags=tags,

--- a/waspy/transports/rabbitmqtransport.py
+++ b/waspy/transports/rabbitmqtransport.py
@@ -9,8 +9,9 @@ from ..webtypes import Request, Response
 
 
 class RabbitMQClientTransport(ClientTransportABC):
-    def __init__(self):
-        raise NotImplementedError
+    def __init__(self, channel):
+        self.channel = channel
+
 
     def make_request(self, service: str, method: str, path: str,
                      body: bytes = None, query: str = None,
@@ -41,7 +42,7 @@ class RabbitMQTransport(TransportABC):
         self._handler = None
 
     def get_client(self):
-        return RabbitMQClientTransport()
+        return RabbitMQClientTransport(self.channel)
 
     async def declare_exchange(self):
         pass

--- a/waspy/webtypes.py
+++ b/waspy/webtypes.py
@@ -100,7 +100,10 @@ class Request:
     def json(self) -> dict:
         if not self._json:
             # convert body into a json dict
-            self._json = json.loads(self.body.decode())
+            try:
+                self._json = json.loads(self.body.decode())
+            except json.JSONDecodeError as ex:
+                raise JSONDecodeError from ex
         return self._json
 
     def get_path_var(self, key, default=None):
@@ -183,3 +186,8 @@ class ResponseError(Exception):
         self.response = Response(status=status, body=body, headers=headers,
                                  correlation_id=correlation_id)
         self.log = log
+
+
+class JSONDecodeError(ResponseError):
+    status = 400
+    reason = 'Invalid Json'


### PR DESCRIPTION
Add the ability to use actions on the same route portion as an ID.

example:
/api/foo/123:archive

Also, remove ability to use `/foo/:id` in creating routes

