### PR TITLE
allow getting config part as dict

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,9 +36,21 @@ def test_get_config_file(config):
     assert config['wasp']['setting1'] == 1
 
 
+def test_get_config_as_dict(config):
+    assert isinstance(config.as_dict(), dict)
+
+
 def test_get_file_subsection(config):
     assert config['database']['username'] == 'normal_user'
     assert config['database']['migration']['username'] == 'migration_user'
+
+
+def test_get_file_sub_section_as_dict(config):
+    assert isinstance(config['wasp'].as_dict(), dict)
+
+
+def test_get_file_sub_section_as_dict_value(config):
+    assert config['database'].as_dict().get('username') == 'normal_user'
 
 
 def test_get_file_flat(config):
@@ -82,6 +94,5 @@ def test_get_flat_with_underscores(config):
 def test_get_flat_with_underscores_envvar(config, monkeypatch):
     monkeypatch.setenv('FLAT_WITH_UNDERSCORES', 'blarg')
     assert config['flat_with_underscores'] == 'blarg'
-
 
 

--- a/waspy/configuration.py
+++ b/waspy/configuration.py
@@ -51,6 +51,9 @@ class Config:
         if self.default_options is None:
             self._load_config()
 
+    def as_dict(self):
+        return dict(self.default_options)
+
     def _load_config(self, filepath=None):
         if filepath is None:
             if CONFIG_LOCATION is None:


### PR DESCRIPTION
Adding support to get the config items as a dict. this allows me to do things like this:
`config.yaml`
```yaml
postgres:
  host: localhost
  port: 5432
  user: postgres
  password: pass
```

and in `dp.py`
```python
async def get_db(app):
    pg = app['config']['postgres']
    app['db'] = await create_engine(**pg.as_dict())
```

This works, as the keys in the yaml, have the same argument names as `create_engine`