### PR TITLE
Router prefixes

### DIFF
--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -17,6 +17,18 @@ def router():
     router_.add_get('/foo/{fooid}:action', 9)
     router_.add_get('/foo/{fooid}:action2', 10)
 
+    with router_.prefix('/test'):
+        router_.add_get('/test', 11)
+
+    with router_.prefix('/nest-1'):
+        with router_.prefix('/nest-2'):
+            with router_.prefix('/nest-3/{nest3id}'):
+                with router_.prefix('/nest-4'):
+                    router_.add_get('/nest-4-get', 4)
+                    with router_.prefix('/nest-5'):
+                        router_.add_get('/nest-5-get', 5)
+                    router_.add_get('/nest-4-get-2', 42)
+
     # now wrap all handlers with nothing
     handler_gen = router_._get_and_wrap_routes()
 
@@ -41,6 +53,10 @@ def router():
     ('/multiple/_ids/_in/_a/row', 8, ['ids', 'in', 'a']),
     ('/foo/_fooid:action', 9, ['fooid']),
     ('/foo/_fooid:action2', 10, ['fooid']),
+    ('/test/test', 11, []),
+    ('/nest-1/nest-2/nest-3/_nest3id/nest-4/nest-4-get', 4, ['nest3id']),
+    ('/nest-1/nest-2/nest-3/_nest3id/nest-4/nest-4-get-2', 42, ['nest3id']),
+    ('/nest-1/nest-2/nest-3/_nest3id/nest-4/nest-5/nest-5-get', 5, ['nest3id'])
 ])
 def test_get_handler(path, expected_handler, expected_params, router):
     # Set up dummy request
@@ -51,7 +67,7 @@ def test_get_handler(path, expected_handler, expected_params, router):
 
     wrapped_handler = router.get_handler_for_request(request)
     handler = request._handler
-    assert handler == expected_handler
+    assert expected_handler == handler
     for key in expected_params:
         assert key in request.path_params
         assert request.path_params[key] == '_' + key

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -6,28 +6,28 @@ from waspy.router import Router, Methods
 @pytest.fixture
 def router():
     router_ = Router()
-    router_.add_get('/single', 1)
-    router_.add_get('/double/double', 2)
-    router_.add_get('/something/static/and/long', 3)
-    router_.add_get('/single/{id}', 4)
-    router_.add_get('/foo/{fooid}/bar/{barid}', 5)
-    router_.add_get('/foo/{fooid}/bar', 6)
-    router_.add_get('/foo/bar/baz/{id}', 7)
-    router_.add_get('/multiple/{ids}/{in}/{a}/row', 8)
-    router_.add_get('/foo/{fooid}:action', 9)
-    router_.add_get('/foo/{fooid}:action2', 10)
+    router_.get('/single', 1)
+    router_.get('/double/double', 2)
+    router_.get('/something/static/and/long', 3)
+    router_.get('/single/{id}', 4)
+    router_.get('/foo/{fooid}/bar/{barid}', 5)
+    router_.get('/foo/{fooid}/bar', 6)
+    router_.get('/foo/bar/baz/{id}', 7)
+    router_.get('/multiple/{ids}/{in}/{a}/row', 8)
+    router_.get('/foo/{fooid}:action', 9)
+    router_.get('/foo/{fooid}:action2', 10)
 
     with router_.prefix('/test'):
-        router_.add_get('/test', 11)
+        router_.get('/test', 11)
 
     with router_.prefix('/nest-1'):
         with router_.prefix('/nest-2'):
             with router_.prefix('/nest-3/{nest3id}'):
                 with router_.prefix('/nest-4'):
-                    router_.add_get('/nest-4-get', 4)
+                    router_.get('/nest-4-get', 4)
                     with router_.prefix('/nest-5'):
-                        router_.add_get('/nest-5-get', 5)
-                    router_.add_get('/nest-4-get-2', 42)
+                        router_.get('/nest-5-get', 5)
+                    router_.get('/nest-4-get-2', 42)
 
     # now wrap all handlers with nothing
     handler_gen = router_._get_and_wrap_routes()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -72,3 +72,12 @@ def test_get_handler(path, expected_handler, expected_params, router):
         assert key in request.path_params
         assert request.path_params[key] == '_' + key
 
+
+def test_duplicate_handler():
+    router_ = Router()
+    router_.get('/test/path', 5)
+
+    with pytest.raises(ValueError):
+        router_.get('/test/path', 6)
+
+    router_.get('/test/path/{param}', 5)

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -129,6 +129,7 @@ class Router:
         """
         if isinstance(method, str):
             method = Methods(method.upper())
+        route = self._prefix + route
         route = route.lstrip('/').replace('/', '.')
         if route not in self._static_routes:
             self._static_routes[route] = {}

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from enum import Enum
 
 from waspy import webtypes
@@ -50,6 +52,7 @@ class Router:
         self.options_handler = None
 
         self.handle_404 = _send_404  # the 404 route will skip middlewares
+        self._prefix = ''
 
     def _get_and_wrap_routes(self, _d=None):
         if _d is None:
@@ -132,6 +135,7 @@ class Router:
         if not isinstance(method, Methods):
             method = Methods(method.upper())
 
+        route = self._prefix + route
         route = route.replace('/', '.').lstrip('.')
         d = self._routes
         params = []
@@ -181,3 +185,12 @@ class Router:
         Add a handler for all options requests. This WILL bypass middlewares
         """
         self.options_handler = handler
+
+    @contextmanager
+    def prefix(self, prefix):
+        original_prefix = self._prefix
+        self._prefix += prefix
+        yield self
+        self._prefix = original_prefix
+
+

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -160,7 +160,8 @@ class Router:
             if key not in d:
                 d[key] = {}
             d = d[key]
-
+        if method in d:
+            raise ValueError(f"Duplicate route exists {method}")
         d[method] = handler, params
 
     def get(self, route: str, handler: Callable):

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -1,4 +1,7 @@
+import warnings
+
 from contextlib import contextmanager
+from typing import Callable, Union
 
 from enum import Enum
 
@@ -113,7 +116,7 @@ class Router:
         request._raw_path = raw_path_string
         return wrapped
 
-    def add_static_route(self, method: str, route: str, handler: callable,
+    def add_static_route(self, method: str, route: str, handler: Callable,
                          skip_middleware=False):
         """
         Adds a static route. A static route is a special route that
@@ -131,8 +134,8 @@ class Router:
             self._static_routes[route] = {}
         self._static_routes[route][method] = handler
 
-    def add_route(self, method: str, route: str, handler: callable):
-        if not isinstance(method, Methods):
+    def add_route(self, method: Union[str, Methods], route: str, handler: Callable):
+        if isinstance(method, str):
             method = Methods(method.upper())
 
         route = self._prefix + route
@@ -159,28 +162,56 @@ class Router:
 
         d[method] = handler, params
 
-    def add_get(self, route: str, handler: callable):
+    def get(self, route: str, handler: Callable):
         self.add_route(Methods.GET, route, handler)
 
-    def add_post(self, route: str, handler: callable):
+    def post(self, route: str, handler: Callable):
         self.add_route(Methods.POST, route, handler)
 
-    def add_put(self, route: str, handler: callable):
+    def put(self, route: str, handler: Callable):
         self.add_route(Methods.PUT, route, handler)
 
-    def add_delete(self, route: str, handler: callable):
-        self.add_route(Methods.DELETE, route, handler)
-
-    def add_patch(self, route: str, handler: callable):
+    def patch(self, route: str, handler: Callable):
         self.add_route(Methods.PATCH, route, handler)
 
-    def add_head(self, route: str, handler: callable):
+    def delete(self, route: str, handler: Callable):
+        self.add_route(Methods.DELETE, route, handler)
+
+    def head(self, route: str, handler: Callable):
         self.add_route(Methods.HEAD, route, handler)
 
-    def add_options(self, route: str, handler: callable):
+    def options(self, route: str, handler: Callable):
         self.add_route(Methods.OPTIONS, route, handler)
 
-    def add_generic_options_handler(self, handler: callable):
+    def add_get(self, route: str, handler: Callable):
+        warnings.warn("add_get is deprecated, use get instead", DeprecationWarning)
+        self.add_route(Methods.GET, route, handler)
+
+    def add_post(self, route: str, handler: Callable):
+        warnings.warn("add_post is deprecated, use post instead", DeprecationWarning)
+        self.add_route(Methods.POST, route, handler)
+
+    def add_put(self, route: str, handler: Callable):
+        warnings.warn("add_put is deprecated, use put instead", DeprecationWarning)
+        self.add_route(Methods.PUT, route, handler)
+
+    def add_delete(self, route: str, handler: Callable):
+        warnings.warn("add_delete is deprecated, use delete instead", DeprecationWarning)
+        self.add_route(Methods.DELETE, route, handler)
+
+    def add_patch(self, route: str, handler: Callable):
+        warnings.warn("add_patch is deprecated, use patch instead", DeprecationWarning)
+        self.add_route(Methods.PATCH, route, handler)
+
+    def add_head(self, route: str, handler: Callable):
+        warnings.warn("add_head is deprecated, use head instead", DeprecationWarning)
+        self.add_route(Methods.HEAD, route, handler)
+
+    def add_options(self, route: str, handler: Callable):
+        warnings.warn("add_options is deprecated, use options instead", DeprecationWarning)
+        self.add_route(Methods.OPTIONS, route, handler)
+
+    def add_generic_options_handler(self, handler: Callable):
         """
         Add a handler for all options requests. This WILL bypass middlewares
         """
@@ -188,6 +219,9 @@ class Router:
 
     @contextmanager
     def prefix(self, prefix):
+        """
+        Adds a prefix to routes contained within.
+        """
         original_prefix = self._prefix
         self._prefix += prefix
         yield self

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -116,7 +116,7 @@ class Router:
         request._raw_path = raw_path_string
         return wrapped
 
-    def add_static_route(self, method: str, route: str, handler: Callable,
+    def add_static_route(self, method: Union[str, Methods], route: str, handler: Callable,
                          skip_middleware=False):
         """
         Adds a static route. A static route is a special route that
@@ -127,7 +127,7 @@ class Router:
 
         All static routes SKIP middlewares
         """
-        if not isinstance(method, Methods):
+        if isinstance(method, str):
             method = Methods(method.upper())
         route = route.lstrip('/').replace('/', '.')
         if route not in self._static_routes:


### PR DESCRIPTION
Allows nesting of routes.

Example usage:

```python
with router.prefix('/nest-1'):
     with router.prefix('/nest-2'):
          with router.prefix('/nest-3/{nest3id}'):
               with router.prefix('/nest-4'):
                    router.add_get('/nest-4-get', handler_4)
                    with router.prefix('/nest-5'):
                        router.add_get('/nest-5-get', handler_5)
                    router.add_get('/nest-4-get-2', handler_42)
```