### PR TITLE
Helpers for creating RabbitMQ Topics from router

### DIFF
--- a/tests/test_rabbitmq_transport.py
+++ b/tests/test_rabbitmq_transport.py
@@ -1,0 +1,20 @@
+import pytest
+from waspy.router import Methods
+from waspy.transports.rabbitmqtransport import parse_url_to_topic
+
+
+@pytest.mark.parametrize("url,expected_topic", [
+    ((Methods.GET, '/single'), "get.single"),
+    ((Methods.GET, '/double/double'), "get.double.double"),
+    ((Methods.GET, '/something/static/and/long'), "get.something.static.and.long"),
+    ((Methods.GET, '/single/{id}'), "get.single.*"),
+    ((Methods.GET, '/foo/{fooid}/bar/{barid}'), "get.foo.*.bar.*"),
+    ((Methods.GET, '/foo/{fooid}/bar'), "get.foo.*.bar"),
+    ((Methods.GET, '/foo/bar/baz/{id}'), "get.foo.bar.baz.*"),
+    ((Methods.GET, '/multiple/{ids}/{in}/{a}/row'), "get.multiple.*.*.*.row"),
+    ((Methods.GET, '/foo/{fooid}:action'), "get.foo.*"),
+    ((Methods.GET, '/foo/{fooid}:action2'), "get.foo.*"),
+    ((Methods.GET, '/test/test'), "get.test.test"),
+])
+def test_url_to_topic(url, expected_topic):
+    assert parse_url_to_topic(*url) == expected_topic

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -81,3 +81,23 @@ def test_duplicate_handler():
         router_.get('/test/path', 6)
 
     router_.get('/test/path/{param}', 5)
+
+def test_urls(router):
+    urls = [
+        (Methods.GET, '/single'),
+        (Methods.GET, '/double/double'),
+        (Methods.GET, '/something/static/and/long'),
+        (Methods.GET, '/single/{id}'),
+        (Methods.GET, '/foo/{fooid}/bar/{barid}'),
+        (Methods.GET, '/foo/{fooid}/bar'),
+        (Methods.GET, '/foo/bar/baz/{id}'),
+        (Methods.GET, '/multiple/{ids}/{in}/{a}/row'),
+        (Methods.GET, '/foo/{fooid}:action'),
+        (Methods.GET, '/foo/{fooid}:action2'),
+        (Methods.GET, '/test/test'),
+        (Methods.GET, '/nest-1/nest-2/nest-3/{nest3id}/nest-4/nest-4-get'),
+        (Methods.GET, '/nest-1/nest-2/nest-3/{nest3id}/nest-4/nest-5/nest-5-get'),
+        (Methods.GET, '/nest-1/nest-2/nest-3/{nest3id}/nest-4/nest-4-get-2')
+    ]
+    for idx, url in enumerate(urls):
+        assert url == router.urls[idx]

--- a/waspy/router.py
+++ b/waspy/router.py
@@ -1,3 +1,4 @@
+import re
 import warnings
 
 from contextlib import contextmanager
@@ -56,6 +57,9 @@ class Router:
 
         self.handle_404 = _send_404  # the 404 route will skip middlewares
         self._prefix = ''
+
+        # A list of tuples (method, url)
+        self.urls = []
 
     def _get_and_wrap_routes(self, _d=None):
         if _d is None:
@@ -140,6 +144,7 @@ class Router:
             method = Methods(method.upper())
 
         route = self._prefix + route
+        self.urls.append((method, route))
         route = route.replace('/', '.').lstrip('.')
         d = self._routes
         params = []


### PR DESCRIPTION
Breaking changes:
  - RabbitMQ Client now makes requests prefixed with the method. `get.topic.pattern` instead of `topic.pattern`

Enhancements:
  - Router now offers a list of URLs and methods. `router.urls == [(Methods.GET, '/foo/bar)]`


Usage Example:

```
# core.py
rabbit = RabbitMQTransport(
    url=config['rabbitmq']['url'],
    port=config['rabbitmq']['port'],
    queue=config['rabbitmq']['queue'],
    virtualhost=config['rabbitmq']['virtualhost'],
    username=config['rabbitmq']['username'],
    password=config['rabbitmq']['password'],
    ssl=config['rabbitmq']['ssl'],
    verify_ssl=config['rabbitmq']['verify_ssl']
)


async def on_start(app):
    await rabbit.register_router(app.router)
```