### PR TITLE
Logging, Shutdown Hooks, Bug Fix

### DIFF
--- a/waspy/transports/httptoolstransport.py
+++ b/waspy/transports/httptoolstransport.py
@@ -169,7 +169,7 @@ class HTTPTransport(TransportABC):
             port=self.port,
             reuse_address=True,
             reuse_port=True)
-        logger.info(f'-- Listening for HTTP on port {self.port} --')
+        print(f'-- Listening for HTTP on port {self.port} --')
         try:
             await self._done_future
         except asyncio.CancelledError:

--- a/waspy/transports/httptoolstransport.py
+++ b/waspy/transports/httptoolstransport.py
@@ -169,11 +169,13 @@ class HTTPTransport(TransportABC):
             port=self.port,
             reuse_address=True,
             reuse_port=True)
-        print('-- Listening for HTTP on port {} --'.format(self.port))
+        logger.info(f'-- Listening for HTTP on port {self.port} --')
         try:
             await self._done_future
         except asyncio.CancelledError:
             pass
+
+        logger.warning("Shutting down HTTP transport")
         await asyncio.sleep(self.shutdown_wait_period)
         # wait for connections to stop
         times_no_connections = 0

--- a/waspy/transports/httptransport.py
+++ b/waspy/transports/httptransport.py
@@ -1,10 +1,14 @@
 import asyncio
+import logging
 import socket
 
 import h11
 
 from ..webtypes import Request, Response, ResponseError
 from .transportabc import TransportABC, ClientTransportABC
+
+
+logger = logging.getLogger("waspy")
 
 
 class ClosedError(Exception):
@@ -139,10 +143,11 @@ class HTTPTransport(TransportABC):
         self._sleeping_connections = set()
 
     def listen(self, *, loop: asyncio.AbstractEventLoop, config):
+        logger.info("Starting http transport")
         coro = asyncio.start_server(
             self.handle_incoming_request, '0.0.0.0', self.port, loop=loop)
         self._server = loop.run_until_complete(coro)
-        print('-- Listening for HTTP on port {} --'.format(self.port))
+        logger.info(f'-- Listening for HTTP on port {self.port} --')
 
     async def start(self, request_handler):
         self._handler = request_handler
@@ -152,8 +157,7 @@ class HTTPTransport(TransportABC):
             pass
 
         # Enter shutdown step
-
-        print('shutting down http')
+        logger.warning("Shutting down HTTP transport")
         self._shutting_down = True
         for coro in self._sleeping_connections:
             coro.cancel()

--- a/waspy/transports/httptransport.py
+++ b/waspy/transports/httptransport.py
@@ -143,7 +143,7 @@ class HTTPTransport(TransportABC):
         self._sleeping_connections = set()
 
     def listen(self, *, loop: asyncio.AbstractEventLoop, config):
-        logger.info("Starting http transport")
+        print("-- Listening for HTTP on port {self.port} --")
         coro = asyncio.start_server(
             self.handle_incoming_request, '0.0.0.0', self.port, loop=loop)
         self._server = loop.run_until_complete(coro)

--- a/waspy/transports/rabbitmqtransport.py
+++ b/waspy/transports/rabbitmqtransport.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import uuid
 
 import aioamqp
@@ -6,6 +7,9 @@ from aioamqp.channel import Channel
 
 from .transportabc import TransportABC, ClientTransportABC
 from ..webtypes import Request, Response, Methods
+
+
+logger = logging.getLogger("waspy")
 
 
 class RabbitChannelMixIn:
@@ -207,6 +211,7 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
                                       routing_key=routing_key)
 
     async def start(self, handler):
+        logger.info(f"-- Listening for rabbitmq messages on queue {self.queue} --")
         self._handler = handler
         # ToDo: Need to reconnect because of potential forking affects
         # await self.close()
@@ -221,10 +226,10 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
         except asyncio.CancelledError:
             pass
 
-        print('shutting down rabbit')
         # shutting down
-        await self.channel.basic_cancel(self._consumer_tag)
-
+        logger.info("Shutting down rabbitmq transport")
+        await self.channel.basic_cancel(self._consumer_tag, no_wait=True)
+        await self.close()
         while self._counter > 0:
             await asyncio.sleep(1)
 
@@ -240,8 +245,6 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
                 await self.channel.queue_declare(queue_name=self.queue)
 
         loop.run_until_complete(setup())
-        print('-- Listening for rabbitmq messages on queue {} --'
-              .format(self.queue))
 
     async def close(self):
         self._closing = True
@@ -311,7 +314,6 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
         self._counter -= 1
 
     def shutdown(self):
-        print('Rabbit got shutdown signal')
         self._done_future.cancel()
 
     async def _bootstrap_channel(self, channel):

--- a/waspy/transports/rabbitmqtransport.py
+++ b/waspy/transports/rabbitmqtransport.py
@@ -211,7 +211,7 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
                                       routing_key=routing_key)
 
     async def start(self, handler):
-        logger.info(f"-- Listening for rabbitmq messages on queue {self.queue} --")
+        print(f"-- Listening for rabbitmq messages on queue {self.queue} --")
         self._handler = handler
         # ToDo: Need to reconnect because of potential forking affects
         # await self.close()
@@ -227,8 +227,8 @@ class RabbitMQTransport(TransportABC, RabbitChannelMixIn):
             pass
 
         # shutting down
-        logger.info("Shutting down rabbitmq transport")
-        await self.channel.basic_cancel(self._consumer_tag, no_wait=True)
+        logger.warning("Shutting down rabbitmq transport")
+        await self.channel.basic_cancel(self._consumer_tag)
         await self.close()
         while self._counter > 0:
             await asyncio.sleep(1)


### PR DESCRIPTION
Bug fix:
   - We were not closing rabbitmq down properly. Calling .close() inside rabbitmq transport

Logging:
   - Implemented logger everywhere
   - Stopped printing

Startup/Shutdown hooks:
   - Implemented shutdown hooks
   - Hooks can now be sync as well as async