### PR TITLE
Listeners

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'pyyaml==3.12',
         'aenum==1.4.5'
     ],
-    packages=['waspy', 'waspy.transports'],
+    packages=['waspy', 'waspy.transports', 'waspy.listeners'],
     long_description=long_description,
     long_desciption_comtent_type='text/markdown',
     url='https://github.com/wasp/waspy',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,5 +83,6 @@ def test_get_flat_with_underscores_envvar(config, monkeypatch):
     monkeypatch.setenv('FLAT_WITH_UNDERSCORES', 'blarg')
     assert config['flat_with_underscores'] == 'blarg'
 
-
-
+def test_using_in_syntax(config):
+    assert 'flat' in config
+    assert 'nope' not in config

--- a/waspy/app.py
+++ b/waspy/app.py
@@ -46,7 +46,7 @@ class Application:
     def __init__(self,
                  transport: Union[TransportABC,
                                   Iterable[TransportABC]]=None,
-                 *,
+                 *, 
                  middlewares: List[callable]=None,
                  default_headers: dict=None,
                  debug: bool=False,
@@ -56,13 +56,13 @@ class Application:
         if transport is None:
             from waspy.transports.httptransport import HTTPTransport
             transport = HTTPTransport()
-        if isinstance(transport, list):   
+        if isinstance(transport, (list, set)):   
             transport = tuple(transport)
         if not isinstance(transport, tuple):
             transport = (transport,)
         if middlewares is None:
             middlewares = ()
-        middlewares = tuple([m for m in middlewares])
+        middlewares = tuple(m for m in middlewares)
         middlewares += (response_wrapper_factory,)
         if router is None:
             router = Router()

--- a/waspy/configuration.py
+++ b/waspy/configuration.py
@@ -77,6 +77,13 @@ class Config:
             return default
         return env
 
+    def __contains__(self, item):
+        try:
+            self.__getitem__(item)
+            return True
+        except ConfigError:
+            return False
+
     def _create_basename(self, item):
         if self.basename:
             return self.basename + '.' + item

--- a/waspy/listeners/rabbitmq_listener.py
+++ b/waspy/listeners/rabbitmq_listener.py
@@ -1,0 +1,111 @@
+import json
+
+import aioamqp
+
+from waspy.listeners.transport_listener_abc import TransportListenerABC
+from waspy.transports.rabbitmqtransport import RabbitMQTransport
+
+
+class RabbitMQTransportListener(TransportListenerABC):
+    queue = ''
+    exchange = ''
+    routing_key = ''
+
+    exchange_type = 'topic'
+    declare_exchange = True
+    declare_queue = True
+
+    durable = True
+    auto_delete = False
+    exclusive = False
+    no_wait = False
+    prefetch_count = 1
+
+    use_acks = True
+    nack_on_error = True
+    requeue_nacks = True
+
+    json_payload = True
+
+    def __init__(self, ):
+        self.transport = None
+        self.channel: aioamqp.channel.Channel = None
+
+        self._consumer_tag = None
+        self._bootstrapped = False
+
+    async def set_channel(self, channel):
+        self._bootstrapped = False
+        if self.channel and self.channel.is_open:
+            await self.transport.close_channel(self.channel)
+        self.channel = channel
+        await self._bootstrap_channel()
+
+    def set_transport(self, transport: RabbitMQTransport):
+        if not isinstance(transport, RabbitMQTransport):
+            raise TypeError(
+                "Invalid transport received. "\
+                f"Expected {type(RabbitMQTransport)}, got type{transport}"
+                )
+        self.transport = transport
+    
+    async def start(self):
+        if not self.channel:
+            self.channel = await self.transport.create_channel()
+        await self._bootstrap_channel()
+
+        resp = await self.channel.basic_consume(
+            self._handle_work,
+            queue_name=self.queue,
+            no_ack=not self.use_acks
+        )
+        self._consumer_tag = resp.get('consumer_tag')
+
+    async def _handle_work(self, _, body, envelope, properties):
+        if self.json_payload:
+            body = json.loads(body)
+        try:
+            await self.handle_work(body, evelope=envelope, properties=properties)
+        except Exception as e:
+            if self.nack_on_error and self.use_acks:
+                await self.channel.basic_client_nack(envelope.delivery_tag, requeue=self.requeue_nacks)
+            raise e
+        else:
+            if self.use_acks:
+                await self.channel.basic_client_ack(envelope.delivery_tag)
+
+    async def exchange_declare(self):
+        """ Override this method to change how a exchange is declared """
+        await self.channel.exchange_declare(
+            self.exchange,
+            self.exchange_type,
+            durable=self.durable,
+            auto_delete=self.auto_delete,
+            no_wait=self.no_wait,
+        )
+
+    async def queue_declare(self):
+        """ Override this method to change how a queue is declared """ 
+        await self.channel.queue_declare(
+                self.queue,
+                durable=self.durable,
+                exclusive=self.exclusive,
+                no_wait=self.no_wait
+            )
+
+    async def _bootstrap_channel(self):
+        if self._bootstrapped:
+            return
+        self._bootstrapped = True
+        await self.channel.basic_qos(prefetch_count=self.prefetch_count)
+        if self.declare_queue:
+            await self.queue_declare()
+        if self.exchange:
+            if self.declare_exchange:
+                await self.exchange_declare()
+            await self.channel.queue_bind(
+                self.queue,
+                self.exchange,
+                self.routing_key,
+            )
+

--- a/waspy/listeners/transport_listener_abc.py
+++ b/waspy/listeners/transport_listener_abc.py
@@ -9,5 +9,5 @@ class TransportListenerABC(ABC):
         pass
 
     @abstractmethod
-    async def handle_work(self, data: Dict, envelope: Dict=None, properties: Dict=None) -> None:
+    async def handle_work(self, data: Dict, **kwargs) -> None:
         pass

--- a/waspy/listeners/transport_listener_abc.py
+++ b/waspy/listeners/transport_listener_abc.py
@@ -1,0 +1,13 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class TransportListenerABC(ABC):
+
+    @abstractmethod
+    async def start(self) -> None:
+        pass
+
+    @abstractmethod
+    async def handle_work(self, data: Dict, envelope: Dict=None, properties: Dict=None) -> None:
+        pass

--- a/waspy/transports/httptransport.py
+++ b/waspy/transports/httptransport.py
@@ -194,8 +194,7 @@ class HTTPTransport(TransportABC):
             lambda: _HTTPServerProtocol(parent=self, loop=self._loop),
             host='0.0.0.0',
             port=self.port,
-            reuse_address=True,
-            reuse_port=True)
+            reuse_address=True)
         print(f'-- Listening for HTTP on port {self.port} --')
         try:
             await self._done_future
@@ -382,5 +381,5 @@ class _HTTPServerProtocol(asyncio.Protocol):
         self.attempt_close()
 
     def attempt_close(self):
-        if self.request == 0:
+        if self.request == 0 and self._transport:
             self._transport.close()


### PR DESCRIPTION
The example will automatically start listeners when the transport starts. These listeners are able to create their own queues/exchanges as needed and are self contained. The transport will manage reconnections/restarting them if something happens to the base protocol. 

`core.py`
```python
from .transport_listeners import queue_1
...

def get_app():
    ...
    rabbit = RabbitMQTransport(**rabbit_kwargs)
    rabbit.add_listener(queue_1.Queue1Listener())
    ...
    return app
```


`transport_listeners/queue_1.py`

```python
from waspy.transports.listeners.rabbitmq_listener import RabbitMQTransportListener


class Queue1Listener(RabbitMQTransportListener):
    queue = 'listener.queue.1'
    exchange = 'waspy.topic.1'
    routing_key = 'queue.1.listen'

    declare_exchange = True

    async def handle_work(self, data: dict):
        print(data)
```

