### PR TITLE
Dont test serialization

### DIFF
--- a/waspy/app.py
+++ b/waspy/app.py
@@ -195,8 +195,6 @@ class Application:
                 if r.log:
                     exc_info = sys.exc_info()
                     self.logger.log_exception(request, exc_info, level='warning')
-            # invoke serialization (json) to make sure it works
-            _ = response.body
 
         except CancelledError:
             # This error can happen if a client closes the connection


### PR DESCRIPTION
Do not try to test serialization in cases where the app is simply acting for a proxy for unknown content types.